### PR TITLE
Bug fixes

### DIFF
--- a/src/main/java/gov/usdot/cv/security/cert/CertificateWrapper.java
+++ b/src/main/java/gov/usdot/cv/security/cert/CertificateWrapper.java
@@ -51,7 +51,7 @@ public class CertificateWrapper {
 	protected final CryptoProvider cryptoProvider;
 	protected final CryptoHelper cryptoHelper;
 	
-	private static CertificateWrapper rootPublicCertificate;
+	private static volatile CertificateWrapper rootPublicCertificate;
 
 	/**
 	 * Instantiates empty certificate wrapper with new cryptographic provider

--- a/src/main/java/gov/usdot/cv/security/cert/FileCertificateStore.java
+++ b/src/main/java/gov/usdot/cv/security/cert/FileCertificateStore.java
@@ -87,7 +87,7 @@ public class FileCertificateStore {
 			byte[]  privateKeyReconstructionValueBytes = null;
 			try {
 				privateKeyReconstructionValueBytes = FileUtils.readFileToByteArray(privateKeyReconstructionFilePath.toFile());
-			} catch (IOException | NullPointerException ex ) {
+			} catch (IOException ex ) {
 				log.error("Coulnd't read file '" + privateKeyReconstructionFilePath + "'. Reason: " + ex.getMessage(), ex);
 			}
 			

--- a/src/main/java/gov/usdot/cv/security/cert/FileCertificateStore.java
+++ b/src/main/java/gov/usdot/cv/security/cert/FileCertificateStore.java
@@ -87,7 +87,7 @@ public class FileCertificateStore {
 			byte[]  privateKeyReconstructionValueBytes = null;
 			try {
 				privateKeyReconstructionValueBytes = FileUtils.readFileToByteArray(privateKeyReconstructionFilePath.toFile());
-			} catch (Exception ex ) {
+			} catch (IOException | NullPointerException ex ) {
 				log.error("Coulnd't read file '" + privateKeyReconstructionFilePath + "'. Reason: " + ex.getMessage(), ex);
 			}
 			

--- a/src/main/java/gov/usdot/cv/security/msg/IEEE1609p2Message.java
+++ b/src/main/java/gov/usdot/cv/security/msg/IEEE1609p2Message.java
@@ -141,10 +141,11 @@ public class IEEE1609p2Message {
 			Ieee1609Dot2Data message = Ieee1609dot2Helper.decodeCOER(msgBytes, new Ieee1609Dot2Data());
 			Uint8 version = message.getProtocolVersion();
 			if(!version.equalTo(protocolVersion)) {
+            int protocolVersionInt = protocolVersion.intValue();
 				throw new MessageException(
 							String.format("Unexpected Protocol Version value. Expected %d, Actual: %d.",
 											version,
-											protocolVersion.intValue()));
+											protocolVersionInt));
 			}
 			
 			Ieee1609Dot2Content content = message.getContent();
@@ -182,10 +183,11 @@ public class IEEE1609p2Message {
         
         Uint8 version = message.getProtocolVersion();
         if(!version.equalTo(protocolVersion)) {
+            int protocolVersionInt = protocolVersion.intValue();
             throw new MessageException(
                         String.format("Unexpected Protocol Version value. Expected %d, Actual: %d.",
                                         version,
-                                        protocolVersion.intValue()));
+                                        protocolVersionInt));
         }
         
         Ieee1609Dot2Content content = message.getContent();


### PR DESCRIPTION
https://github.com/usdot-jpo-ode/jpo-security/compare/bugfixes?expand=1#diff-aba90de3aaebf659da80ffbb1cece7f2R54 added `volatile` since double-locked checking seems to still have weaknesses

`int protocolVersionInt = protocolVersion.intValue();` Sonar is falsely claiming that "An int is expected rather than a Uint8", but its probably cleaner to do this instead of adding //NOSONAR