### PR TITLE
Switch to synchronized methods instead of double-locked checking

### DIFF
--- a/src/main/java/gov/usdot/cv/security/cert/CertificateWrapper.java
+++ b/src/main/java/gov/usdot/cv/security/cert/CertificateWrapper.java
@@ -51,7 +51,7 @@ public class CertificateWrapper {
 	protected final CryptoProvider cryptoProvider;
 	protected final CryptoHelper cryptoHelper;
 	
-	private static volatile CertificateWrapper rootPublicCertificate;
+	private static CertificateWrapper rootPublicCertificate;
 
 	/**
 	 * Instantiates empty certificate wrapper with new cryptographic provider
@@ -445,13 +445,9 @@ public class CertificateWrapper {
 	 * Retrieves certificate's signing certificate instance
 	 * @return certificate's signing certificate
 	 */
-	static private CertificateWrapper getRootPublicCertificate() {
-		if ( rootPublicCertificate == null ) {
-			synchronized(Certificate.class) {
-				if ( rootPublicCertificate == null )
-					rootPublicCertificate = CertificateManager.get(rootPublicCertificateFriendlyName);
-			}
-		}
+	static synchronized private CertificateWrapper getRootPublicCertificate() {
+		if ( rootPublicCertificate == null )
+			rootPublicCertificate = CertificateManager.get(rootPublicCertificateFriendlyName);
 		return rootPublicCertificate;
 	}
 	

--- a/src/main/java/gov/usdot/cv/security/msg/IEEE1609p2Message.java
+++ b/src/main/java/gov/usdot/cv/security/msg/IEEE1609p2Message.java
@@ -141,11 +141,10 @@ public class IEEE1609p2Message {
 			Ieee1609Dot2Data message = Ieee1609dot2Helper.decodeCOER(msgBytes, new Ieee1609Dot2Data());
 			Uint8 version = message.getProtocolVersion();
 			if(!version.equalTo(protocolVersion)) {
-            int protocolVersionInt = protocolVersion.intValue();
 				throw new MessageException(
 							String.format("Unexpected Protocol Version value. Expected %d, Actual: %d.",
 											version,
-											protocolVersionInt));
+											protocolVersion.intValue()));
 			}
 			
 			Ieee1609Dot2Content content = message.getContent();
@@ -183,11 +182,10 @@ public class IEEE1609p2Message {
         
         Uint8 version = message.getProtocolVersion();
         if(!version.equalTo(protocolVersion)) {
-            int protocolVersionInt = protocolVersion.intValue();
             throw new MessageException(
                         String.format("Unexpected Protocol Version value. Expected %d, Actual: %d.",
                                         version,
-                                        protocolVersionInt));
+                                        protocolVersion.intValue()));
         }
         
         Ieee1609Dot2Content content = message.getContent();
@@ -657,16 +655,14 @@ public class IEEE1609p2Message {
 	 * @return self certificate
 	 * @throws CertificateException 
 	 */
-	private CertificateWrapper getSelfCertificate() throws CertificateException {
-		if (selfCertificate == null) {
-			synchronized(this) {
-				if (selfCertificate == null) {
-					selfCertificate = CertificateManager.get(IEEE1609p2Message.selfCertificateFriendlyName);
-					if ( selfCertificate == null )
-						throw new CertificateException(String.format("Self certificate with name '%s' was not found", IEEE1609p2Message.selfCertificateFriendlyName));
+	private synchronized CertificateWrapper getSelfCertificate() throws CertificateException {
+
+			if (selfCertificate == null) {
+				selfCertificate = CertificateManager.get(IEEE1609p2Message.selfCertificateFriendlyName);
+				if ( selfCertificate == null ) {
+					throw new CertificateException(String.format("Self certificate with name '%s' was not found", IEEE1609p2Message.selfCertificateFriendlyName));
 				}
 			}
-		}
 
 		return selfCertificate;
 	}


### PR DESCRIPTION
Reading this article https://www.cs.umd.edu/~pugh/java/memoryModel/DoubleCheckedLocking.html makes it sound like there's only two ways to really fix this: `synchronized` or `volatile`.

Sonar doesn't like volatile variables unless they are atomic.